### PR TITLE
Rolls back separation of dynamic and static builds

### DIFF
--- a/Configurations/Product/DynamicFramework.xcconfig
+++ b/Configurations/Product/DynamicFramework.xcconfig
@@ -39,5 +39,3 @@ CODE_SIGN_IDENTITY =
 // For example from an application bundle (inside the "Frameworks" folder) or shared folder.
 LD_DYLIB_INSTALL_NAME = @rpath/$(PRODUCT_NAME).$(WRAPPER_EXTENSION)/$(PRODUCT_NAME)
 DYLIB_INSTALL_NAME_BASE = @rpath
-
-CONFIGURATION_BUILD_DIR=$(BUILD_DIR)/$(CONFIGURATION)-dynamic-$(EFFECTIVE_PLATFORM_NAME)


### PR DESCRIPTION
Fixes https://github.com/parse-community/Parse-SDK-iOS-OSX/pull/1427