### PR TITLE
Removes OS versions from Simulator specs

### DIFF
--- a/Scripts/xctask/build_framework_task.rb
+++ b/Scripts/xctask/build_framework_task.rb
@@ -77,7 +77,7 @@ module XCTask
     def build_ios_framework
       framework_paths = []
       framework_paths << build_framework('iphoneos')
-      framework_paths << build_framework('iphonesimulator', '"platform=iOS Simulator,name=iPhone 11,OS=13.2.2"')
+      framework_paths << build_framework('iphonesimulator', 'platform="iOS Simulator",name="iPhone 11"')
       final_path = final_framework_path
 
       system("rm -rf #{final_path} && cp -R #{framework_paths[0]} #{final_path}")
@@ -102,7 +102,7 @@ module XCTask
     def build_watchos_framework
       framework_paths = []
       framework_paths << build_framework('watchos')
-      framework_paths << build_framework('watchsimulator', '"platform=watchOS Simulator,OS=6.1,name=Apple Watch Series 5 - 44mm"')
+      framework_paths << build_framework('watchsimulator', 'platform="watchOS Simulator",name="Apple Watch Series 5 - 44mm"')
       final_path = final_framework_path
 
       system("rm -rf #{final_path} && cp -R #{framework_paths[0]} #{final_path}")
@@ -127,7 +127,7 @@ module XCTask
     def build_tvos_framework
       framework_paths = []
       framework_paths << build_framework('appletvos')
-      framework_paths << build_framework('appletvsimulator', '"platform=tvOS Simulator,OS=13.2,name=Apple TV 4K"')
+      framework_paths << build_framework('appletvsimulator', 'platform="tvOS Simulator",name="Apple TV 4K"')
       final_path = final_framework_path
 
       system("rm -rf #{final_path} && cp -R #{framework_paths[0]} #{final_path}")


### PR DESCRIPTION
I've noticed there's some tiresome version-chasing going on re Simulators. Apple changed the way they supply Xcode, and only provide the latest OS version of the Simulator as standard. So every time a new version of Xcode gets released, our scripts break.

I see 2 ways to deal with this. One would be to get Xcode to download a set version of the simulator and specify that in our scripts. The other is to remove the version requirement in the scripts, such that Xcode uses the version that it has.

This change represents the second option.